### PR TITLE
v1.6.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dysgu/htslib"]
-	path = dysgu/htslib
-	url = https://github.com/samtools/htslib.git

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -25,6 +25,10 @@ echo "Build threads:" $threads
 echo "htslib_folder:" $htslib_folder
 echo "Extra configure args:" $@
 
+cd dysgu
+wget https://github.com/samtools/htslib/releases/download/1.18/htslib-1.18.tar.bz2
+tar -xvf htslib-1.18.tar.bz2 && rm htslib-1.18.tar.bz2 && mv htslib-1.18 htslib
+cd ../
 
 if [[ $htslib_folder == "./dysgu/htslib" ]]
 then

--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ Suitable values for `--pass-prob` often lie in the range 0.2 - 0.4. For paired-e
 
     dysgu filter --pass-prob 0.2 --min-prob 0.1 --normal-vcf normal.vcf tumour.vcf normal.bam > somatic.vcf
 
-To quickly test and visualise different filtering thresholds, output can be piped to the command line tool `GW <https://kcleal.github.io/dysgu/API.html>`_, or `jupyter notebook <https://github.com/kcleal/gw>`_, which will display the results to screen for inspection::
+To quickly test and visualise different filtering thresholds, output can be piped to the command line tool `GW <https://github.com/kcleal/gw>`_, which will display the results to screen for inspection::
 
     dysgu filter --pass-prob 0.2 filtered.vcf | \
     gw hg38 -b normal.bam -b tumor.bam -v - 

--- a/README.rst
+++ b/README.rst
@@ -202,7 +202,6 @@ see the dysgu_api_demon.ipynb
 
 Specifying regions of interest / excluding regions
 --------------------------------------------------
-
 Regions of the genome can be skipped from analysis by providing a .bed file using the `--exclude` option. This option
 takes precedence over the options detailed below, and acts as a hard filter, removing regions of the genome from analysis.
 

--- a/dysgu/assembler.pyx
+++ b/dysgu/assembler.pyx
@@ -38,11 +38,10 @@ ctypedef map_set_utils.Py_IntSet Py_IntSet
 ctypedef EventResult EventResult_t
 
 
-cdef extern from "wrap_map_set2.h" nogil:
+cdef extern from "graph_objects.hpp" nogil:
 
     cdef cppclass TwoWayMap:
         TwoWayMap() nogil
-
         uint64_t key_2_64(char, uint64_t, uint64_t, uint64_t) nogil
         void insert_tuple_key(uint64_t, int) nogil
         int has_tuple_key(uint64_t) nogil
@@ -290,7 +289,7 @@ cdef int topo_sort2(DiGraph& G, cpp_deque[int]& order): #  except -1:
             if new_nodes.size() > 0:
                 new_nodes.clear()
 
-            neighbors = G.neighbors(w)
+            G.neighbors(w, neighbors)
             for n in neighbors:
                 if explored.find(n) == explored.end():
 
@@ -335,16 +334,12 @@ cdef cpp_deque[int] score_best_path(DiGraph& G, cpp_deque[int]& nodes_to_visit, 
         return path
 
     with nogil:
-
         for i in range(0, len_nodes):
-
             u = nodes_to_visit[i]
             node_weight = n_weights[u]
 
             # Find best incoming node scores, best inEdge, and also best predecessor node
-
-            neighborList = G.forInEdgesOf(u)
-
+            G.forInEdgesOf(u, neighborList)
             if neighborList.size() == 0:
                 node_scores[u] = node_weight
                 if node_weight >= best_score:
@@ -377,7 +372,6 @@ cdef cpp_deque[int] score_best_path(DiGraph& G, cpp_deque[int]& nodes_to_visit, 
     if best_node == -1:
         return path
     # Start traceback from best scoring node, use locally best edge to trace path back
-
     u = best_node
     while True:
         path.push_front(u)

--- a/dysgu/call_component.pyx
+++ b/dysgu/call_component.pyx
@@ -766,17 +766,6 @@ cdef single(rds, int insert_size, int insert_stdev, float insert_ppf, int clip_l
                 svlen = svlen_adjusted
                 er.preciseA = True
                 er.preciseB = True
-                # if min_fractional_overlapping(posA_adjusted, posB_adjusted, spanning_alignments[index][2], spanning_alignments[index][3]) < 0.8:
-                #     to_assemble = False
-                #     er.preciseA = False
-                #     er.preciseB = False
-                #     posA = posA_adjusted
-                #     posB = posB_adjusted
-                #     svlen = svlen_adjusted
-                # else:
-                #     er.preciseA = True
-                #     er.preciseB = True
-                #     svlen = int(np.median([sp[4] for sp in spanning_alignments]))
             else:
                 # to_assemble = False
                 er.preciseA = True

--- a/dysgu/extra_metrics.pyx
+++ b/dysgu/extra_metrics.pyx
@@ -40,7 +40,6 @@ class BadClipCounter:
             self.clip_pos_arr[chrom].write(position.to_bytes(4, byteorder))
 
     def sort_arrays(self):
-
         if not self.low_mem:
             self.clip_pos_arr = [np.array(i, dtype=np.dtype("i")) for i in self.clip_pos_arr]
         else:
@@ -52,7 +51,7 @@ class BadClipCounter:
     def count_near(self, int chrom, int start, int end):
         py_a = self.clip_pos_arr[chrom]
         cdef int len_a = len(py_a)
-        if chrom < 0 or chrom >= len_a or len_a == 0:
+        if chrom < 0 or len_a == 0:
             return 0
         cdef int[:] a = py_a
         if start < 0:
@@ -261,6 +260,7 @@ cpdef filter_poorly_aligned_ends(spanning_alignments, float divergence=0.02):
 
 
 cpdef gap_size_upper_bound(AlignedSegment alignment, int cigarindex, int pos_input, int end_input, int length_extend=15, float divergence=0.02):
+    # expand indel using cigar, merges nearby gaps into the SV event
     cdef int pos, end, l, opp, extent_left, extent_right, candidate_type, candidate_len, len_input, i, dist, dist_thresh, middle, last_seen_size
     cdef uint32_t cigar_value
     cdef uint32_t cigar_l = alignment._delegate.core.n_cigar

--- a/dysgu/graph_objects.hpp
+++ b/dysgu/graph_objects.hpp
@@ -31,12 +31,9 @@ class DiGraph {
         int n_edges = 0;
 
         int addNode() {
-
             int n = N;
-
             std::vector<PairW2> node;
             std::vector<PairW2> in_node;
-
             outList.push_back(node);  // empty, no edges
             inList.push_back(in_node);
             N++;
@@ -45,15 +42,12 @@ class DiGraph {
 
         int hasEdge(int u, int v) {
             if ((u > N ) || (v > N)) { return 0; }
-
-            // Look for v
             for (const auto& val: outList[u]) {
                 if (val.first == v) {
                     return 1;
                 }
             }
             return 0;
-
         }
 
         void addEdge(int u, int v, int w) {
@@ -71,93 +65,65 @@ class DiGraph {
                 n_edges += 1;
                 return;
             }
-
-//            for (auto& val: outList[u]) {
-//                if (val.first == v) {
-//                    val.second += w;
-//                    return;
-//                }
-//            }
-//
-//            outList[u].push_back(std::make_pair(v, w));
-//            inList[v].push_back(std::make_pair(u, w));
-//            n_edges += 1;
-
             bool updated = false;
             for (auto& val: outList[u]) {
                 if (val.first == v) {
                     val.second += w;
-                    //return;
                     updated = true;
                 }
             }
-
             if (updated == false) {
                 outList[u].push_back(std::make_pair(v, w));
                 n_edges += 1;
             }
-
             updated = false;
-
             for (auto& vali: inList[v]) {
                 if (vali.first == u) {
                     vali.second += w;
-                    //return;
                     updated = true;
                 }
             }
-
             if (updated == false) {
                 inList[v].push_back(std::make_pair(u, w));
             }
-
         }
 
         int weight(int u, int v) {
-
             if ((u > N ) || (v > N)) { return 0; }
-
             for (const auto& val: outList[u]) {
                 if (val.first == v) {
                     return val.second;
                 }
             }
-
             return 0;
         }
 
         int numberOfNodes() { return N; }
 
-
-        std::vector<int> neighbors(int u) {  // Get all out edges
-
-            std::vector<int> neigh;
-
+        void neighbors(int u, std::vector<int> &neigh) {  // Get all out edges
+            //std::vector<int> neigh;
+            if (!neigh.empty()) {
+                neigh.clear();
+            }
             for (const auto& val: outList[u]) {
                 neigh.push_back(val.first);
             }
-
-            return neigh;
-
+            //return neigh;
         }
 
 
-        std::vector<PairW2> forInEdgesOf(int u) {
-
-            std::vector<PairW2> inEdges;
-
+        void forInEdgesOf(int u, std::vector<PairW2>& inEdges) {
+//            std::vector<PairW2> inEdges;
+            if (!inEdges.empty()) {
+                inEdges.clear();
+            }
             for (const auto& val: inList[u]) {
                 inEdges.push_back(val);
             }
-
-            return inEdges;
-
+//            return inEdges;
         }
 
         float node_path_quality(int u, int v, int w) {
-
-//            std::cerr << u << "u " << v << "v " << w << "w " << std::endl;
-
             int sum_in = 0;
             float q_in = 1;
             if (u != -1) {
@@ -170,7 +136,6 @@ class DiGraph {
                     q_in = in_weight / sum_in;
                 }
             }
-
             int sum_out = 0;
             float q_out = 1;
             if (w != -1) {
@@ -183,13 +148,9 @@ class DiGraph {
                     q_out = out_weight / sum_out;
                 }
             }
-
             if (q_out < q_in) { return q_out; };
             return q_in;
-
         }
-
-
 };
 
 
@@ -200,160 +161,116 @@ class SimpleGraph {
         SimpleGraph() {}  // Construct
         ~SimpleGraph() {}
 
-        // Used for undirected graph
         std::vector<std::vector<PairW>> adjList;
-
-        // Used for directed graph
-//        std::vector<std::vector<PairW>> inList;
-//        std::vector<std::vector<PairW>> outList;
 
         int N = 0;
         int n_edges = 0;
 
-
         int addNode() {
-
             int n = N;
-
             std::vector<PairW> node;
-//            node.push_back(std::make_pair(-1, -1));
             adjList.push_back(node);
-
             N++;
             return n;
         }
 
         int hasEdge(int u, int v) {
             if ((u > N ) || (v > N)) { return 0; }
-
-            // Look for v
             for (const auto& val: adjList[u]) {
                 if (val.first == v) {
                     return 1;
                 }
             }
             return 0;
-
         }
 
         void addEdge(int u, int v, uint8_t w) {
-
-            // Assume hasEdge has been call
-            // If node has no edge add first in, otherwise push a new node
-//            if ((adjList[u].size() == 1) && (adjList[u].front().first == -1)) {
-//                adjList[u].front().first = v;
-//                adjList[u].front().second = w;
-//            } else {
-//                adjList[u].push_back(std::make_pair(v, w));
-//            };
-//
-//            if ((adjList[v].size() == 1) && (adjList[v].front().first == -1)) {
-//                adjList[v].front().first = u;
-//                adjList[v].front().second = w;
-//            } else {
-//                adjList[v].push_back(std::make_pair(u, w));
-//            };
-
             adjList[u].push_back(std::make_pair(v, w));
             adjList[v].push_back(std::make_pair(u, w));
-
             n_edges += 1;
-
         }
 
         int edgeCount() { return n_edges; }
 
         int weight(int u, int v) {
-
             if ((u > N ) || (v > N)) { return 0; }
-
             for (const auto& val: adjList[u]) {
                 if (val.first == v) {
                     return val.second;
                 }
             }
-
             return 0;
         }
 
-        std::vector<int> neighbors(int u) {
-
-            std::vector<int> neigh;
-
+        void neighbors(int u, std::vector<int>& neigh) {
+//            std::vector<int> neigh;
+            if (!neigh.empty()) {
+                neigh.clear();
+            }
             for (const auto& val: adjList[u]) {
                 neigh.push_back(val.first);
             }
-
-            return neigh;
-
+//            return neigh;
         }
 
         void removeNode(int u) {
+            // make dead nodes, takes more memory but faster
+            for (auto& val_u: adjList[u]) {
+                for (auto& val_v: adjList[val_u.first]) {
+                    if (val_v.first == u) {
+                        val_v.first = -1;
+                        val_v.second = -1;
+                    }
+                }
+            }
             // Set node edges to empty
             std::vector<PairW> node;
             node.push_back(std::make_pair(-1, -1));
             adjList[u] = node;
         }
 
-        std::vector<int> connectedComponents(const char* outpath, bool low_mem) {
-
+        void connectedComponents(const char* outpath, bool low_mem, std::vector<int>& components) {
             std::string outpath_string = outpath;
-
             std::ofstream outf(outpath);
-
             std::vector<bool> visited(adjList.size(), false);
-
-            std::vector<int> components;
-
+            if (!components.empty()) {
+                components.clear();
+            }
+//            std::vector<int> components;
             for (int u=0; u<N; u++) {
-
                 if (visited[u] == false) {
-
                     if (!low_mem) {
                         components.push_back(u);
                     } else {
                         outf.write((char*)&u, sizeof(int32_t));
                     }
                     visited[u] = true;
-
-
                     std::vector<int> queue;
                     // visit direct neighbors
                     if (adjList[u].size() > 0) {
-
                         for (const auto& val: adjList[u]) {
-
                             if ((val.first != -1) && (visited[val.first] == false)) {
                                 queue.push_back(val.first);
                             }
                         }
                     }
-
-
                     while (!queue.empty()) {
                         int v = queue.back();
                         queue.pop_back();
-
                         if (visited[v] == false) {
-//                            components.push_back(v);
-
                             if (!low_mem) {
                                 components.push_back(v);
                             } else {
                                 outf.write((char*)&v, sizeof(int32_t));
                             }
-
                             visited[v] = true;
-
                             for (const auto& val2: adjList[v]) {
-
                                 if ((val2.first != -1) && (visited[val2.first] == false)) {
                                     queue.push_back(val2.first);
                                 }
                             }
                         }
                     }
-
                     // -1 is end of component
                     if (!low_mem) {
                         components.push_back(-1);
@@ -361,15 +278,10 @@ class SimpleGraph {
                         int v = -1;
                         outf.write((char*)&v, sizeof(int32_t));
                     }
-//                    components.push_back(-1);
                 }
             }
-
             outf.close();
-
-            return components;
-
-
+//            return components;
         }
 
         std::size_t showSize() {
@@ -381,12 +293,8 @@ class SimpleGraph {
                 }
             }
             return tot;  // bytes
-
         }
-
-
 };
-
 
 
 typedef std::pair<int, int> lookup_result;
@@ -422,7 +330,6 @@ class Int2IntMap
         }
 
     private:
-//        tsl::robin_map<int, int> map;
         robin_hood::unordered_flat_map<int, int> map;
 };
 
@@ -445,7 +352,6 @@ class IntSet
         }
 
     private:
-//        tsl::robin_set<int> set;
         robin_hood::unordered_set<int> set;
 };
 
@@ -467,14 +373,11 @@ class TwoWayMap
         }
 
         void insert_tuple_key(uint64_t packed_data, int index) {
-//            string_key.insert_or_assign(packed_data, index);
-//            string_key.insert(std::make_pair(packed_data, index));
             string_key[packed_data] = index;
             index_key_map.push_back(packed_data);
         }
 
         int has_tuple_key(uint64_t packed_data) {
-//            tsl::robin_map<uint64_t, int>::const_iterator got = string_key.find(packed_data);
             robin_hood::unordered_flat_map<uint64_t, int>::const_iterator got = string_key.find(packed_data);
             if (got == string_key.end()) {
                 return 0;
@@ -504,7 +407,6 @@ class TwoWayMap
         }
 
     private:
-
         uint64_t last_key = 0;  // Set this on call to has_tuple_key to prevent calculating twice
         int last_index = 0;
         robin_hood::unordered_flat_map<uint64_t, int> string_key;
@@ -529,7 +431,6 @@ class MinimizerTable
 // Key's are read-names (integer), the table value is a set with each item a minimizer (long)
 {
     public:
-
         MinimizerTable() {}
         ~MinimizerTable() {}
 
@@ -549,8 +450,8 @@ class MinimizerTable
 
         set_of_long_t::iterator get_iterator_begin () {
             return itr->second.begin();
-//            return set_itr;
         }
+
         set_of_long_t::iterator get_iterator_end () {
             return itr->second.end();
         }
@@ -569,12 +470,10 @@ class MinimizerTable
             return set_itr;
         }
 
-
     private:
         mm_map_t mm_map;
         mm_map_t::iterator itr;
         set_of_long_t::iterator set_itr;
-
 };
 
 

--- a/dysgu/main.py
+++ b/dysgu/main.py
@@ -26,7 +26,7 @@ defaults = {
             "svs_out": "-",
             "max_cov": 200,
             "buffer_size": 0,
-            "min_support": 3,
+            "min_support": "3",
             "min_size": 30,
             "model": None,
             "max_tlen": 1000,
@@ -44,8 +44,8 @@ defaults = {
             }
 
 
-presets = {"nanopore": {"mq": 20,
-                        "min_support": 3,
+presets = {"nanopore": {"mq": 1,
+                        "min_support": "auto",
                         "dist_norm": 900,
                         "max_cov": 150,
                         "pl": "nanopore",
@@ -53,8 +53,8 @@ presets = {"nanopore": {"mq": 20,
                         "clip_length": -1,
                         "trust_ins_len": "False"
                         },
-           "pacbio": {"mq": 20,
-                      "min_support": 3,
+           "pacbio": {"mq": 1,
+                      "min_support": "auto",
                       "dist_norm": 600,
                       "max_cov": 150,
                       "pl": "pacbio",
@@ -168,8 +168,8 @@ def cli():
 @click.option("-p", "--procs", help="Number of cpu cores to use", type=cpu_range, default=1,
               show_default=True)
 @click.option('--mode', help="Type of input reads. Multiple options are set, overrides other options. "
-                             "pacbio: --mq 20 --paired False --min-support 3 --max-cov 150 --dist-norm 200 --trust-ins-len True. "
-                             "nanopore: --mq 20 --paired False --min-support 3 --max-cov 150 --dist-norm 900 --trust-ins-len False",
+                             "pacbio: --mq 20 --paired False --min-support 'auto' --max-cov 150 --dist-norm 200 --trust-ins-len True. "
+                             "nanopore: --mq 20 --paired False --min-support 'auto' --max-cov 150 --dist-norm 900 --trust-ins-len False",
               default="pe", type=click.Choice(["pe", "pacbio", "nanopore"]), show_default=True)
 @click.option('--pl', help=f"Type of input reads  [default: {defaults['pl']}]",
               type=click.Choice(["pe", "pacbio", "nanopore"]), callback=add_option_set)
@@ -180,7 +180,7 @@ def cli():
               type=str, callback=add_option_set)
 @click.option('--max-tlen', help="Maximum template length to consider when calculating paired-end template size",
               default=defaults["max_tlen"], type=int, show_default=True)
-@click.option('--min-support', help=f"Minimum number of reads per SV  [default: {defaults['min_support']}]", type=int, callback=add_option_set)
+@click.option('--min-support', help=f"Minimum number of reads per SV  [default: {defaults['min_support']}]", type=str, callback=add_option_set)
 @click.option('--min-size', help="Minimum size of SV to report",
               default=defaults["min_size"], type=int, show_default=True)
 @click.option('--mq', help=f"Minimum map quality < threshold are discarded  [default: {defaults['mq']}]",
@@ -207,7 +207,7 @@ def cli():
 @click.option("--drop-gaps", help="Drop SVs near gaps +/- 250 bp of Ns in reference",
               default="True", type=click.Choice(["True", "False"]), show_default=True)
 @click.option("--merge-dist", help="Attempt merging of SVs below this distance threshold. Default for paired-end data is (insert-median + 5*insert_std) for paired"
-                                   "reads, or 500 bp for single-end reads",
+                                   "reads, or 700 bp for single-end reads",
               default=None, type=int, show_default=False)
 @click.option("--paired", help="Paired-end reads or single", default="True",
               type=click.Choice(["True", "False"]), show_default=True)
@@ -324,9 +324,10 @@ def get_reads(ctx, **kwargs):
 @click.option('--pfix', help="Post-fix of temp alignment file (used when a working-directory is provided instead of "
                              "sv-aligns)",
               default="dysgu_reads", type=str, required=False)
-@click.option('--mode', help="Type of input reads. Multiple options are set, overrides other options"
-                             " pacbio/nanopore: --mq 20 --paired False --min-support 3 --max-cov 150", default="pe",
-              type=click.Choice(["pe", "pacbio", "nanopore"]), show_default=True)
+@click.option('--mode', help="Type of input reads. Multiple options are set, overrides other options. "
+                             "pacbio: --mq 20 --paired False --min-support 'auto' --max-cov 150 --dist-norm 200 --trust-ins-len True. "
+                             "nanopore: --mq 20 --paired False --min-support 'auto' --max-cov 150 --dist-norm 900 --trust-ins-len False",
+              default="pe", type=click.Choice(["pe", "pacbio", "nanopore"]), show_default=True)
 @click.option('--pl', help=f"Type of input reads  [default: {defaults['pl']}]",
               type=click.Choice(["pe", "pacbio", "nanopore"]), callback=add_option_set)
 @click.option('--clip-length', help="Minimum soft-clip length, >= threshold are kept. Set to -1 to ignore", default=defaults["clip_length"],
@@ -336,7 +337,7 @@ def get_reads(ctx, **kwargs):
               type=str, callback=add_option_set)
 @click.option('--max-tlen', help="Maximum template length to consider when calculating paired-end template size",
               default=defaults["max_tlen"], type=int, show_default=True)
-@click.option('--min-support', help=f"Minimum number of reads per SV  [default: {defaults['min_support']}]", type=int, callback=add_option_set)
+@click.option('--min-support', help=f"Minimum number of reads per SV  [default: {defaults['min_support']}]", type=str, callback=add_option_set)
 @click.option('--min-size', help="Minimum size of SV to report",
               default=defaults["min_size"], type=int, show_default=True)
 @click.option('--mq', help=f"Minimum map quality < threshold are discarded  [default: {defaults['mq']}]",
@@ -364,7 +365,7 @@ def get_reads(ctx, **kwargs):
 @click.option("--drop-gaps", help="Drop SVs near gaps +/- 250 bp of Ns in reference",
               default="True", type=click.Choice(["True", "False"]), show_default=True)
 @click.option("--merge-dist", help="Attempt merging of SVs below this distance threshold, default is (insert-median + 5*insert_std) for paired"
-                                   "reads, or 500 bp for single-end reads",
+                                   "reads, or 700 bp for single-end reads",
               default=None, type=int, show_default=False)
 @click.option("--paired", help="Paired-end reads or single", default="True",
               type=click.Choice(["True", "False"]), show_default=True)

--- a/dysgu/map_set_utils.pxd
+++ b/dysgu/map_set_utils.pxd
@@ -67,7 +67,7 @@ cdef extern from "robin_hood.h" namespace "robin_hood" nogil:
         bint empty()
 
 
-cdef extern from "find_reads.h" nogil:
+cdef extern from "find_reads.hpp" nogil:
     cdef cppclass CoverageTrack:
         CoverageTrack() nogil
 
@@ -79,13 +79,13 @@ cdef extern from "find_reads.h" nogil:
         void set_max_cov(int)
 
 
-cdef extern from "wrap_map_set2.h":
+cdef extern from "graph_objects.hpp":
     ctypedef struct Interval:
         int low
         int high
 
 
-cdef extern from "wrap_map_set2.h":
+cdef extern from "graph_objects.hpp":
     cdef cppclass BasicIntervalTree:
         BasicIntervalTree()
         void add(int, int, int)
@@ -107,7 +107,7 @@ cdef class Py_BasicIntervalTree:
     cpdef int countOverlappingIntervals(self, int pos, int pos2)
 
 
-cdef extern from "wrap_map_set2.h" nogil:
+cdef extern from "graph_objects.hpp" nogil:
     cdef cppclass DiGraph:
         DiGraph() nogil
 
@@ -117,8 +117,8 @@ cdef extern from "wrap_map_set2.h" nogil:
         int weight(int, int)
         void updateEdge(int, int, int)
         int numberOfNodes() nogil
-        cpp_vector[cpp_pair[int, int]] forInEdgesOf(int) nogil
-        cpp_vector[int] neighbors(int) nogil
+        void forInEdgesOf(int, cpp_vector[cpp_pair[int, int]]&) nogil
+        void neighbors(int, cpp_vector[int]&) nogil
         float node_path_quality(int, int, int) nogil
 
 
@@ -131,12 +131,12 @@ cdef class Py_DiGraph:
     cdef void addEdge(self, int u, int v, int w)
     cdef void updateEdge(self, int u, int v, int w)
     cdef int numberOfNodes(self) nogil
-    cdef cpp_vector[cpp_pair[int, int]] forInEdgesOf(self, int u) nogil
-    cdef cpp_vector[int] neighbors(self, int u) nogil
+    cdef void forInEdgesOf(self, int u, cpp_vector[cpp_pair[int, int]]& inEdges) nogil
+    cdef void neighbors(self, int u, cpp_vector[int]& neigh) nogil
     cdef float node_path_quality(self, int u, int v, int w) nogil
 
 
-cdef extern from "wrap_map_set2.h" nogil:
+cdef extern from "graph_objects.hpp" nogil:
     cdef cppclass MinimizerTable:
         MinimizerTable() nogil
 
@@ -152,7 +152,7 @@ cdef extern from "wrap_map_set2.h" nogil:
         unordered_set[long].iterator get_iterator_end()
 
 
-cdef extern from "wrap_map_set2.h":
+cdef extern from "graph_objects.hpp":
     cdef cppclass SimpleGraph:
         SimpleGraph()
 
@@ -161,9 +161,9 @@ cdef extern from "wrap_map_set2.h":
         void addEdge(int, int, int)
         int edgeCount()
         int weight(int, int)
-        cpp_vector[int] neighbors(int)
+        void neighbors(int, cpp_vector[int]&)
         void removeNode(int)
-        cpp_vector[int] connectedComponents(char*, bint)
+        void connectedComponents(char*, bint, cpp_vector[int]&)
         int showSize()
 
 
@@ -176,13 +176,13 @@ cdef class Py_SimpleGraph:
     cpdef void addEdge(self, int u, int v, int w)
     cpdef int edgeCount(self)
     cpdef int weight(self, int u, int v)
-    cpdef cpp_vector[int] neighbors(self, int u)
+    cdef void neighbors(self, int u, cpp_vector[int]& neigh)
     cpdef void removeNode(self, int u)
-    cpdef cpp_vector[int] connectedComponents(self, char* pth, bint low_mem)
+    cdef void connectedComponents(self, char* pth, bint low_mem, cpp_vector[int]& neigh)
     cpdef int showSize(self)
 
 
-cdef extern from "wrap_map_set2.h" nogil:
+cdef extern from "graph_objects.hpp" nogil:
     cdef cppclass Int2IntMap:
         Int2IntMap() nogil
         void insert(int, int) nogil
@@ -205,7 +205,7 @@ cdef class Py_Int2IntMap:
     cdef int size(self) nogil
 
 
-cdef extern from "wrap_map_set2.h" nogil:
+cdef extern from "graph_objects.hpp" nogil:
     cdef cppclass IntSet:
         IntSet() nogil
         void insert(int) nogil

--- a/dysgu/map_set_utils.pyx
+++ b/dysgu/map_set_utils.pyx
@@ -142,10 +142,10 @@ cdef class Py_DiGraph:
         self.thisptr.addEdge(u, v, w)
     cdef int numberOfNodes(self) nogil:
         return self.thisptr.numberOfNodes()
-    cdef cpp_vector[cpp_pair[int, int]] forInEdgesOf(self, int u) nogil:
-        return self.thisptr.forInEdgesOf(u)
-    cdef cpp_vector[int] neighbors(self, int u) nogil:
-        return self.thisptr.neighbors(u)
+    cdef void forInEdgesOf(self, int u, cpp_vector[cpp_pair[int, int]]& inEdges) nogil:
+        self.thisptr.forInEdgesOf(u, inEdges)
+    cdef void neighbors(self, int u, cpp_vector[int]& neigh) nogil:
+        self.thisptr.neighbors(u, neigh)
     cdef float node_path_quality(self, int u, int v, int w)  nogil:
         return self.thisptr.node_path_quality(u, v, w)
 
@@ -166,12 +166,12 @@ cdef class Py_SimpleGraph:
         return self.thisptr.edgeCount()
     cpdef int weight(self, int u, int v):
         return self.thisptr.weight(u, v)
-    cpdef cpp_vector[int] neighbors(self, int u):
-        return self.thisptr.neighbors(u)
+    cdef void neighbors(self, int u, cpp_vector[int]& neigh):
+        self.thisptr.neighbors(u, neigh)
     cpdef void removeNode(self, int u):
         self.thisptr.removeNode(u)
-    cpdef cpp_vector[int] connectedComponents(self, char* pth, bint low_mem):
-        return self.thisptr.connectedComponents(pth, low_mem)
+    cdef void connectedComponents(self, char* pth, bint low_mem, cpp_vector[int]& components):
+        self.thisptr.connectedComponents(pth, low_mem, components)
     cpdef int showSize(self):
         return self.thisptr.showSize()
 
@@ -330,8 +330,8 @@ cdef bint span_position_distance(int x1, int x2, int y1, int y2, float norm, flo
     # https://github.com/eldariont/svim/blob/master/src/svim/SVIM_clustering.py
     cdef int span1, span2, max_span
     cdef float span_distance, position_distance, center1, center2
-    if read_enum == BREAKEND:
-        return 0
+    # if read_enum == BREAKEND:
+    #     return 0
     cdef bint within_read_event = cigar_len1 > 0 and cigar_len2 > 0
     if within_read_event and c_abs(cigar_len1 - cigar_len2) > 500:
         return 0
@@ -341,11 +341,6 @@ cdef bint span_position_distance(int x1, int x2, int y1, int y2, float norm, flo
         center1 = x1
         center2 = y1
 
-    # if trust_ins_len and read_enum == INSERTION and cigar_len1 > 0 and cigar_len2 > 0:
-    #     span1 = cigar_len1
-    #     span2 = cigar_len2
-    #     center1 = x1
-    #     center2 = y1
     else:
         if x1 == x2:
             span1 = 1
@@ -373,7 +368,7 @@ cdef bint span_position_distance(int x1, int x2, int y1, int y2, float norm, flo
             return 1
         return 0
 
-    if (position_distance / max_span) < thresh and span_distance < thresh:  # 0.2, 0.3
+    if (position_distance / max_span) < thresh and span_distance < thresh:
         return 1
     return 0
 

--- a/dysgu/re_map.py
+++ b/dysgu/re_map.py
@@ -507,6 +507,5 @@ def drop_svs_near_reference_gaps(events, paired_end, ref_genome, drop_gaps):
                 f'Index error for event region {chrom}:{gstart}-{gend}, event loci: {e.chrA} {e.posA} {e.chrB} {e.posB}')
 
     new_events = [events[i] for i in range(len(events)) if i not in bad_i]
-    logging.info("Number or SVs near gaps dropped {}".format(len(bad_i)))
 
     return new_events

--- a/dysgu/sv2bam.pyx
+++ b/dysgu/sv2bam.pyx
@@ -6,10 +6,12 @@ import time
 import datetime
 from collections import defaultdict
 import os
+import sys
 import itertools
 import logging
 from libc.stdint cimport uint32_t
 
+import pkg_resources
 from dysgu.map_set_utils import echo
 from dysgu.coverage import auto_max_cov
 from dysgu.io_funcs import bed_iter
@@ -133,7 +135,7 @@ def assert_indexed_input(bam, fasta):
     return bam
 
 
-cdef extern from "find_reads.h":
+cdef extern from "find_reads.hpp":
     cdef int search_hts_alignments(char* infile, char* outfile, uint32_t min_within_size, int clip_length, int mapq_thresh,
                                    int threads, int paired_end, char* temp_f, int max_coverage, char* region,
                                    char* max_cov_ignore, char *fasta, bint write_all, char* out_write_mode_b)
@@ -159,6 +161,10 @@ def process(args):
     else:
         bname = "-"
         out_name = args["output"]
+
+    with open(os.path.join(temp_dir, "fetch_command.txt"), "w") as info:
+        info.write(f"# dysgu v{pkg_resources.require('dysgu')[0].version}\n")
+        info.write(" ".join(sys.argv))
 
     # update max cov automatically if applicable
     args["max_cov"] = auto_max_cov(args["max_cov"], args["bam"])

--- a/dysgu/sv_category.pyx
+++ b/dysgu/sv_category.pyx
@@ -271,16 +271,14 @@ cdef void same_read(AlignmentItem v):
                 else:
                     v.breakB = v.endB
 
-                v.svtype = "INS"
+                v.svtype = "DUP"
                 # Check if gap on query is bigger than gap on reference
-                # query_gap = abs(v.b_qstart - v.a_qend) + 1  # as A is first
                 ref_gap = abs(v.breakB - v.breakA)
-
                 if v.a_qstart > v.b_qstart:  # B is first on query seq
                     align_overlap = v.b_qend - v.a_qstart  # note, this is negative if there is a gap between alignments
                 else:
                     align_overlap = v.a_qend - v.b_qstart
-
+                align_overlap = 0 if align_overlap < 0 else align_overlap
                 v.inferred_sv_len = ref_gap - align_overlap
                 if align_overlap < 0:
                     v.query_gap = align_overlap

--- a/dysgu/sv_category.pyx
+++ b/dysgu/sv_category.pyx
@@ -272,13 +272,14 @@ cdef void same_read(AlignmentItem v):
                     v.breakB = v.endB
 
                 v.svtype = "DUP"
+                # v.svtype = "INS"
                 # Check if gap on query is bigger than gap on reference
                 ref_gap = abs(v.breakB - v.breakA)
                 if v.a_qstart > v.b_qstart:  # B is first on query seq
                     align_overlap = v.b_qend - v.a_qstart  # note, this is negative if there is a gap between alignments
                 else:
                     align_overlap = v.a_qend - v.b_qstart
-                align_overlap = 0 if align_overlap < 0 else align_overlap
+                # align_overlap = 0 if align_overlap < 0 else align_overlap
                 v.inferred_sv_len = ref_gap - align_overlap
                 if align_overlap < 0:
                     v.query_gap = align_overlap

--- a/scripts/convert2bnd.py
+++ b/scripts/convert2bnd.py
@@ -1,0 +1,110 @@
+from sys import stdout
+from dysgu.view import read_from_inputfile
+import click
+import pysam
+import copy
+
+
+@click.command()
+@click.option('-t', help="Comma separated list of SVTYPE's to convert to BND format", required=False,
+              type=str, default='TRA', show_default=True)
+@click.option('-o', help='Write vcf to output file', required=False, type=str, default='stdout', show_default=True)
+@click.argument("reference", required=True, type=str)
+@click.argument("input_vcf", required=False, type=str)
+def conver2bnd(t, o, reference, input_vcf):
+    if o == '-' or o == 'stdout':
+        outf = stdout
+    else:
+        outf = open(o, 'w')
+    fin = read_from_inputfile(input_vcf)
+    targets = set(t.split(','))
+    ref = pysam.FastaFile(reference)
+    for line in fin:
+        if line[0] == "#":
+            outf.write(line)
+        else:
+            split = False
+            for svt in targets:
+                if svt in line:
+                    split = svt
+                    break
+            if not split:
+                outf.write(line)
+                continue
+            l = line.split('\t', 8)
+            info = dict(tuple(i.split('=')) for i in l[7].split(';') if '=' in i)
+            ct = info['CT']
+            chrom2 = info['CHR2']
+            if chrom2.startswith("chr"):
+                chrom2 = chrom2[3:]
+            pos2 = info["CHR2_POS"] if "CHR2_POS" in info else info["END"]
+            p = f'{chrom2}:{pos2}'
+            p2 = f'{l[0]}:{l[1]}'
+            ref_base = l[3]
+            ref_base2 = ref.fetch(chrom2, int(pos2), int(pos2)+1).upper()
+            alt_bases = l[4]
+            if alt_bases[0] != '<':
+                add_ins = True
+            else:
+                add_ins = False
+            if ct == '3to5':
+                template = "{t}[{p}["
+                template2 = "]{p}]{t}"
+                if add_ins:
+                    ref_base += alt_bases
+                    ref_base2 = alt_bases + ref_base2
+            elif ct == '5to3':
+                template = "]{p}]{t}"
+                template2 = "{t}[{p}["
+                if add_ins:
+                    ref_base = alt_bases + ref_base
+                    ref_base2 += alt_bases
+            elif ct == '3to3':
+                template = "{t}]{p}]"
+                template2 = "[{p}[{t}"
+                if add_ins:
+                    ref_base += alt_bases
+                    ref_base2 = alt_bases + ref_base2
+            else:
+                template = "[{p}[{t}"
+                template2 = "{t}]{p}]"
+                if add_ins:
+                    ref_base = alt_bases + ref_base
+                    ref_base2 += alt_bases
+
+            # info['SVTYPE'] = 'BND'
+            info2 = copy.deepcopy(info)
+            info2['CHR2'] = l[0]
+            if 'CHR2_POS' in info:
+                info2['CHR2_POS'] = l[1]
+                info2['END'] = str(int(pos2) + 1)
+            else:
+                info['END'] = l[1]
+
+            l2 = copy.deepcopy(l)
+            bnd1 = template.format(p=p, t=ref_base)
+            bnd2 = template2.format(p=p2, t=ref_base2)
+
+            l2[0] = chrom2
+            l2[1] = pos2
+
+            l[4] = bnd1
+            l2[4] = bnd2
+
+            l[7] = ';'.join([f'{i}={j}' for i, j in info.items()])
+            l2[7] = ';'.join([f'{i}={j}' for i, j in info2.items()])
+
+            l[2] += '_1'
+            l2[2] += '_2'
+
+            l = '\t'.join(l)
+            l2 = '\t'.join(l2)
+
+            outf.write(l)
+            outf.write(l2)
+
+    outf.close()
+
+
+if __name__ == '__main__':
+    conver2bnd()

--- a/scripts/coverage2bed.py
+++ b/scripts/coverage2bed.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pandas as pd
+import click
+import glob
+from io import StringIO
+from sys import stderr
+
+
+@click.command()
+@click.option("-w", help="Previous working directory for dysgu, converts all .bin files within -w", required=False, type=click.Path())
+@click.option("-g", help="Converts all .bin files specified using pattern, e.g. 'wd/chr1*.bin", required=False, type=str)
+@click.option("-b", help="Converts single .bin file", required=False, type=click.Path())
+@click.option("--out-bin-size", help="Output bin size in base-pairs, must be a multiple of 100", type=click.IntRange(100, 10000000, clamp=True), default=100, show_default=True)
+@click.option("--opp", help="When merging bins, apply this operation", type=click.Choice(["mean", "min", "max", "median"]), default="median", show_default=True)
+@click.option("--sep", help="Separator", type=click.Choice([",", '\t', " "]), default="\t", show_default=True)
+def convert2bed(w, g, b, out_bin_size, opp, sep):
+    """Convert .dysgu_chrom.bin files to a bed file. Outputs '#chrom, start, end, coverage' columns to stdout"""
+    if w is None and b is None and g is None:
+        raise ValueError("Specify --wd or --bin")
+    if out_bin_size % 100 > 0:
+        raise ValueError("out-bin-size must be a multiple of 100 bp")
+    if w is not None:
+        bin_files = sorted(glob.glob(w + "/*dysgu_chrom.bin"))
+    elif g is not None:
+        bin_files = sorted(glob.glob(g))
+    else:
+        bin_files = [b]
+    if len(bin_files) == 0:
+        raise ValueError("No .bin files detected")
+
+    block_size = int(out_bin_size / 10)
+    print(f"Aggregating {block_size} consecutive bins", file=stderr)
+    chroms = []
+    starts = []
+    ends = []
+    vals = []
+    for pth in bin_files:
+        chrom_name = pth.split("/")[-1].split(".")[0]
+        a = np.fromfile(pth, dtype="int16")
+        for start in range(0, len(a), block_size):
+            end = start + block_size
+            if opp == "median":
+                v = np.median(a[start:end])
+            elif opp == "max":
+                v = np.max(a[start:end])
+            elif opp == "min":
+                v = np.min(a[start:end])
+            elif opp == "mean":
+                v = np.mean(a[start:end])
+            chroms.append(chrom_name)
+            starts.append(start * 10)
+            ends.append((start * 10) + out_bin_size)
+            vals.append(v)
+
+    df = pd.DataFrame()
+    df["#chrom"] = chroms
+    df["start"] = starts
+    df["end"] = ends
+    df["coverage"] = vals
+
+    output = StringIO()
+    df.to_csv(output, index=False, sep=sep)
+    print(output.getvalue())
+
+
+if __name__ == "__main__":
+    convert2bed()

--- a/scripts/suggest_max_coverage.py
+++ b/scripts/suggest_max_coverage.py
@@ -1,0 +1,25 @@
+import click
+from sys import stderr
+import pysam
+from dysgu.coverage import index_stats
+
+
+@click.command()
+@click.argument('alignment_file', required=True, type=click.Path(exists=False))
+@click.option("-y", "--y", help="Max-cov is estimated as {mean-coverage} * y", required=False, type=float,
+              show_default=True, default=6)
+def suggest_max_coverage(alignment_file, y):
+    """Estimate a max-coverage value for use with dysgu. Mean genome coverage is estimated from the index file, so
+    will only be useful for whole-genome alignment files"""
+    f = pysam.AlignmentFile(alignment_file)
+    cov, read_length = index_stats(f)
+    cov = round(cov, 2)
+    read_length = round(read_length, 1)
+    max_cov = round(cov * y)
+    print(f"Read-length {read_length} bp, mean whole-genome coverage estimate: {cov}, max-cov ~ {max_cov}", file=stderr)
+    print(max_cov)
+    return max_cov
+
+
+if __name__ == "__main__":
+    suggest_max_coverage()

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
     url="https://github.com/kcleal/dysgu",
     description="Structural variant calling",
     license="MIT",
-    version='1.5.1',
+    version='1.6.0',
     python_requires='>=3.7',
     install_requires=[  # runtime requires
             'setuptools>=63.0',

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
     url="https://github.com/kcleal/dysgu",
     description="Structural variant calling",
     license="MIT",
-    version='1.5.0',
+    version='1.5.1',
     python_requires='>=3.7',
     install_requires=[  # runtime requires
             'setuptools>=63.0',


### PR DESCRIPTION
Improvements / changes
----------------------
- Added 'auto' option for setting --min-support, this is set as default for long-reads
- Long-reads default mapq lowered to 1
- Improved sensitivity for large-insertions using long-reads
- Small numbers of BND events also now reported for long-reads
- Improved precision due to better SV merging and lower numbers of duplicated true-positive calls
- Coverage values now include reads < mapq threshold
- Around 10 % of insertions are now re-classified as DUP; occurs when split-read support is available
Bug fixes
---------
- Segfault for high coverage sample
- Exponential runtime for very large component in graph