### PR TITLE
Check if input bam file is sorted

### DIFF
--- a/dysgu/cluster.pyx
+++ b/dysgu/cluster.pyx
@@ -1159,31 +1159,7 @@ def cluster_reads(args):
         if kind2 == "stdin" or kind2 == "-" or kind2 not in opts:
             raise ValueError("--ibam must be a .bam/cam/sam file")
         ibam = pysam.AlignmentFile(args["ibam"], opts[kind2], threads=1,
-                                   reference_filename=None if kind2 != "cram" else args["reference"])
-    
-    # Double check if bam file is sorted
-    # first check SO tag in HD
-    if "HD" in infile.header:
-        hd = infile.header["HD"]
-        if "SO" in hd:
-            if hd["SO"] == "unsorted":
-                # raise ValueError for SO:unsorted
-                raise ValueError("Input bam file must be sorted")
-    # directly check bam just check the first 1000 alignment for speed
-    max_alignment_check = 10**3
-    alignment_count = 0
-    prev_alignment = None
-    for aln in infile:
-        alignment_count += 1
-        if alignment_count > max_alignment_check:
-            break
-        if prev_alignment and prev_alignment.reference_id > aln.reference_id:
-            raise ValueError("Input bam file must be sorted")
-        prev_alignment = aln
-    logging.info("Check PASS : Input BAM file is sorted")
-    # reopen infile
-    infile = pysam.AlignmentFile(args["sv_aligns"], bam_mode, threads=args["procs"],
-                                 reference_filename=None if kind != "cram" else args["reference"])     
+                                   reference_filename=None if kind2 != "cram" else args["reference"])        
                                           
     if "RG" in infile.header:
         rg = infile.header["RG"]


### PR DESCRIPTION
Update cluster.pyx

I use two redundant ways to check if bam file is sorted as mentioned in issue [#84](https://github.com/kcleal/dysgu/issues/84).

One is just directly check the SO tag in HD, but some bam file do not have this tag and is still can be unsorted, so I also employ an alternative way to just check the first 1K reads to see if it is sorted.

If the input bam file in unsorted, an Error is raise. If it is sorted, a log is create to log the pass check.

I also run `dysgu test` and all of them pass.

Additionally, I try to run on some unsorted bam file, it works like a charm.
```bash
$ dysgu call -x -o test_unsorted.vcf mm39.fa ~/Downloads/dysgu-master/wd_test mouse_unsorted.bam;

2024-04-14 11:40:38,494 [INFO   ]  call -x -o test_unsorted.vcf ~/dysgu-master/wd_test mouse_unsorted.bam
Traceback (most recent call last):
  File "~dysgu/bin/dysgu", line 33, in <module>
    sys.exit(load_entry_point('dysgu==1.6.3', 'console_scripts', 'dysgu')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "~miniconda3/envs/dysgu/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniconda3/envs/dysgu/lib/python3.12/site-packages/dysgu-1.6.3-py3.12-linux-x86_64.egg/dysgu/main.py", line 420, in call_events
    cluster.cluster_reads(ctx.obj)
  File "dysgu/cluster.pyx", line 1181, in dysgu.cluster.cluster_reads
    raise ValueError("Input bam file must be sorted")
ValueError: Input bam file must be sorted
```


Hope you like my modifications.

